### PR TITLE
Adding compatibility with Banner Jobsub Proxy (banjsproxy)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,20 @@ gem install banner_jobsub
  - [formatr](https://rubygems.org/gems/formatr) >= 1.10.1
 
 ## Configuration
-BannerJobsub expects standard/global configuration values configuration values to be stored in `$BANNER_HOME/admin/banner_jobsub.yaml`. Basic, minimum required values are your SEED1 and SEED3 values:
+BannerJobsub expects standard/global configuration values to be stored in `$BANNER_HOME/admin/banner_jobsub.yaml`. Basic, minimum required values are your SEED1 and SEED3 values:
 ```yaml
 seed_one: 111111111
 seed_three: 22222222
 ```
+
+**Banner 9 / bannerjsproxy** 
+If you are using Banner Job Submission Proxy (bannerjsproxy) with either Banner 8 INB or Banner 9 Admin Pages, you can enable bannerjsproxy compatibility using the (optional) configuration setting. Defaults to disabled.
+```yaml
+seed_one: 111111111
+seed_three: 22222222
+banjsproxy: enabled
+```
+
 More options and configuration values are covered below.
 
 ## Installing a Job

--- a/lib/banner_jobsub.rb
+++ b/lib/banner_jobsub.rb
@@ -35,13 +35,20 @@ module BannerJobsub
         seed_three: nil,
         page_length: 55,
         footer: '\f',
-        header: ''
+        header: '',
+		banjsproxy: 'disabled'
       }
 
       configure_from_files
       configure_from_hash(opts)
       @config.each { |k, v| fail "Required configuration parameter \"#{k}\" is null." if v.nil? }
 
+      # If banner jobsub proxy is marked as enabled, shuffle ENV vars to match Ellucian shenanigans
+      if @config[:banjsproxy].downcase == 'enabled'
+        @config[:password] = ''
+        @config[:instance] = ENV['PSWD']
+      end	  
+	  
       set_db_connection
       set_role_security
 


### PR DESCRIPTION
Enable banjsproxy compatibility for Banner 8 / Banner 9 and set sensible defaults to maintain backwards compatibility.